### PR TITLE
DEVOPS-423: Replace PAT with GitHub App for IaC image tag commits

### DIFF
--- a/.github/workflows/commit-image-tag.yml
+++ b/.github/workflows/commit-image-tag.yml
@@ -15,19 +15,37 @@ on:
       image_tag:
         required: true
         type: string
+      github_app_id:
+        required: true
+        type: string
     secrets:
-      token:
+      github_app_private_key:
         required: true
 
 jobs:
   commit-image-tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Parse repository owner and name
+        id: repo-info
+        run: |
+          echo "owner=$(echo '${{ inputs.git_repository }}' | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+          echo "repo=$(echo '${{ inputs.git_repository }}' | cut -d'/' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ inputs.github_app_id }}
+          private-key: ${{ secrets.github_app_private_key }}
+          owner: ${{ steps.repo-info.outputs.owner }}
+          repositories: ${{ steps.repo-info.outputs.repo }}
+
       - name: Checkout target repo
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.git_repository }}
-          token: ${{ secrets.token }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ inputs.git_branch }}
 
       - name: commit image tag

--- a/.github/workflows/commit-image-tag.yml
+++ b/.github/workflows/commit-image-tag.yml
@@ -51,8 +51,8 @@ jobs:
       - name: commit image tag
         run: |
           echo "Updating image tag to ${{ inputs.image_tag }}"
-          git config --global user.name "DevOps"
-          git config --global user.email "DevOps@email.com"
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ inputs.github_app_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           sed -i.bak 's|\(image_tag[[:space:]]*=[[:space:]]*\)".*"|\1"${{ inputs.image_tag }}"|' ${{ inputs.file_path }}
           rm -f ${{ inputs.file_path }}.bak
           git add ${{ inputs.file_path }}

--- a/.github/workflows/commit-image-tag.yml
+++ b/.github/workflows/commit-image-tag.yml
@@ -51,8 +51,8 @@ jobs:
       - name: commit image tag
         run: |
           echo "Updating image tag to ${{ inputs.image_tag }}"
-          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-          git config --global user.email "${{ inputs.github_app_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[app]"
+          git config --global user.email "${{ inputs.github_app_id }}+${{ steps.app-token.outputs.app-slug }}[app]@users.noreply.github.com"
           sed -i.bak 's|\(image_tag[[:space:]]*=[[:space:]]*\)".*"|\1"${{ inputs.image_tag }}"|' ${{ inputs.file_path }}
           rm -f ${{ inputs.file_path }}.bak
           git add ${{ inputs.file_path }}


### PR DESCRIPTION
Instead of using service account and PAT, switching to Github App which is more secure and no need to maintain a separate service account.